### PR TITLE
scroll控件：修复当高度不是默认的90rpx时，this.data.move没有计算，采用默认的-45导致出现顶部的一大段空白（下拉刷…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/*
 src/config/*.tmp
 src/config/env.js
 npm-debug.log
+/.vs/slnx.sqlite

--- a/components/scroll/index.js
+++ b/components/scroll/index.js
@@ -200,7 +200,8 @@ Component({
 			query.exec(function (res) {
 				this.setData({
 					scrollHeight1: -res[0].height,
-					scrollHeight2: res[1].height - res[0].height,
+          scrollHeight2: res[1].height - res[0].height,
+          move: -res[0].height /*修复当高度不是默认的90rpx时，this.data.move没有计算，采用默认的-45导致出现顶部的一大段空白（下拉刷新后就会正常）的问题。*/
 				})
 			}.bind(this));
 		},


### PR DESCRIPTION
scroll控件：修复当高度不是默认的90rpx时，this.data.move没有计算，采用默认的-45导致出现顶部的一大段空白（下拉刷新后就会正常）的问题。